### PR TITLE
Switch boto3 s3 client to SigV4 by removing deprecated Signature V2 config

### DIFF
--- a/notify.py
+++ b/notify.py
@@ -51,14 +51,14 @@ class Notifier:
                                aws_access_key_id=self.access_key,
                                region_name='default', 
                                aws_secret_access_key=self.secret_key,
-                               config=botocore.client.Config(signature_version = 's3'))
+        )
 
         self.s3 = boto3.client('s3',
                               endpoint_url = self.endpoint_url,
                               aws_access_key_id = self.access_key,
                               aws_secret_access_key = self.secret_key,
                               region_name = 'default',
-                              config=botocore.client.Config(signature_version = 's3'))
+       )
 
 
     ''' This function creates and sns-like topic with configured push endpoint'''


### PR DESCRIPTION
This patch removes the explicit `signature_version="s3"` configuration, [which forces the deprecated Signature V2](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html?utm_source=chatgpt.com#:~:text=Signature%20Version%204-,s3,(Deprecated)%20Signature%20Version%202,-use_accelerate_endpoint%3A%20Specifies%20whether). Modern S3-compatible servers (AWS, RGW, NooBaa) no longer accept SigV2, which resulted in consistent `SignatureDoesNotMatch`
errors when using this tool against current deployments.


By removing the legacy config, boto3 falls back to its default signing method
(Signature V4), which is compatible with all modern S3 endpoints.